### PR TITLE
feat: add preparation stage for more flexible pre-game setup

### DIFF
--- a/src/components/AdminStageController.tsx
+++ b/src/components/AdminStageController.tsx
@@ -116,6 +116,8 @@ export const AdminStageController = () => {
         return "戰鬥階段";
       case "evolution":
         return "進化階段";
+      case "preparation":
+        return "準備階段";
       default:
         return "未知階段";
     }

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -12,7 +12,11 @@ interface PlayerCardProps {
   className?: string;
 }
 
-export const PlayerCard = ({ player, className = "" }: PlayerCardProps) => {
+export const PlayerCard = ({
+  player,
+  showDetailed,
+  className = "",
+}: PlayerCardProps) => {
   return (
     <Card
       className={`border-0 shadow-sm hover:shadow-md transition-shadow ${className} ${
@@ -42,11 +46,13 @@ export const PlayerCard = ({ player, className = "" }: PlayerCardProps) => {
               >
                 {player.nickname}
               </div>
-              <div
-                className={`text-sm text-muted-foreground ${player.isDead ? "text-gray-400 dark:text-gray-500" : ""}`}
-              >
-                {getPlayerTypeLabel(player.type)} • 元素 {player.elementCount}
-              </div>
+              {showDetailed && (
+                <div
+                  className={`text-sm text-muted-foreground ${player.isDead ? "text-gray-400 dark:text-gray-500" : ""}`}
+                >
+                  {getPlayerTypeLabel(player.type)} • 元素 {player.elementCount}
+                </div>
+              )}
             </div>
           </div>
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -121,12 +121,18 @@ export const ROUND_TRAIT_MAP: Record<number, EVOLUTION_TRAITS[]> = {
 };
 
 export enum GAME_STAGE_TYPE {
+  PREPARATION = "preparation",
   DISCUSSION = "discussion",
   COMBAT = "combat",
   EVOLUTION = "evolution",
 }
 
 export const GAME_STAGES: IGameStage[] = [
+  // ========== Round 0 ==========
+  {
+    round: 0,
+    type: GAME_STAGE_TYPE.PREPARATION,
+  },
   // ========== Round 1 ==========
   {
     round: 1,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,7 +5,11 @@ import type {
   EVOLUTION_TRAITS,
 } from "./constants";
 
-export type IGameStage = IDiscussionStage | ICombatStage | IEvolutionStage;
+export type IGameStage =
+  | IDiscussionStage
+  | ICombatStage
+  | IEvolutionStage
+  | IPreparationStage;
 
 export interface IPlayer {
   id: string;
@@ -53,6 +57,10 @@ interface ICombatStage extends IBaseGameStage {
 
 interface IEvolutionStage extends IBaseGameStage {
   type: GAME_STAGE_TYPE.EVOLUTION;
+}
+
+interface IPreparationStage extends IBaseGameStage {
+  type: GAME_STAGE_TYPE.PREPARATION;
 }
 
 export interface ITraitEffectLog {

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -137,6 +137,7 @@ const Player = () => {
   const currentStageIndex = game?.stageIndex ?? 0;
   const currentStage = GAME_STAGES[currentStageIndex];
   const isDiscussionStage = currentStage?.type === GAME_STAGE_TYPE.DISCUSSION;
+  const isPreparationStage = currentStage?.type === GAME_STAGE_TYPE.PREPARATION;
   const hasParasitic = player.evolutionCards?.includes(
     EVOLUTION_TRAITS.PARASITIC,
   );
@@ -176,7 +177,7 @@ const Player = () => {
 
       <div className="w-full max-w-screen-sm mx-auto p-4 space-y-4">
         {/* Player Card */}
-        <PlayerCard player={player} />
+        <PlayerCard player={player} showDetailed={!isPreparationStage} />
 
         {/* Trait Target Selection Section */}
         {shouldShowTraitSelection && (
@@ -386,23 +387,26 @@ const Player = () => {
               <Gamepad2 className="h-4 w-4 text-primary" />
               遊戲資訊
             </h3>
-
             {/* Element Type Info */}
-            <div className="bg-muted/30 rounded-lg p-3">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <div className="text-sm text-muted-foreground">元素類型</div>
-                </div>
-                <div className="text-right">
-                  <div className="font-semibold text-base">
-                    {getPlayerTypeLabel(player.type)}
+            {!isPreparationStage && (
+              <div className="bg-muted/30 rounded-lg p-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="text-sm text-muted-foreground">
+                      元素類型
+                    </div>
                   </div>
-                  <div className="text-xs text-muted-foreground">
-                    元素 {player.elementCount}
+                  <div className="text-right">
+                    <div className="font-semibold text-base">
+                      {getPlayerTypeLabel(player.type)}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      元素 {player.elementCount}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            )}
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
# Description

This PR adds a new `PREPARATION` stage to give game hosts more control over when players can view or access game-related information.

Key improvements include:

- Preparation Phase
  - Introduces a new game status `PREPARATION` to separate setup from active join phase

This allows organizers to prepare the game environment and limit early exposure to player lists, trait visibility, or sensitive setup details.